### PR TITLE
Implement fact sheet summaries and AI crawler governance

### DIFF
--- a/AEO_Optimization_Enhancements.md
+++ b/AEO_Optimization_Enhancements.md
@@ -1,0 +1,39 @@
+# Additional AEO Enhancements for the Parenting Knowledge Base
+
+This memo reviews the proposed optimization checklist and highlights extra refinements that can further strengthen Large Language Model (LLM) discoverability while keeping conventional SEO intact.
+
+## 1. Content Modeling & Information Architecture
+- **Expandable question clusters**: Introduce a `Related Questions` module that links 3–5 narrowly scoped follow-up questions (each with its own canonical page). Expose these links via HTML lists and in structured data (`hasPart` / `isPartOf`) to promote crawl depth.
+- **Structured summary cards**: Add a machine-parsable `<dl>` or JSON snippet summarizing age ranges, contraindications, and professional bodies cited. This gives models a ready-to-consume data capsule in addition to paragraphs and tables.
+- **Cross-jurisdiction patterns**: Where guidance spans more than two regions (e.g., US/CA/UK/EU), standardize a “Regulatory Snapshot” table component with consistent column headers, allowing automated scrapers to map new regions without custom parsing.
+
+## 2. Technical Delivery & Performance
+- **Deterministic URL taxonomy**: Publish a routing schema (e.g., `/en-us/feeding/{topic}/{question-slug}`) in documentation and sitemap comments so ingest pipelines can pre-compute endpoints. Include locale segments and the age bracket taxonomy (`0-6m`, `6-12m`, etc.) for predictable aggregation.
+- **LLM-specific feeds**: Beyond `/ai-feed.ndjson`, provide a `Last-30-days.ndjson` delta feed and an ETag-based `HEAD` endpoint to help crawlers detect freshness without refetching full payloads.
+- **Edge cache headers**: Serve HTML with `Cache-Control: public, max-age=600, stale-while-revalidate=86400` to encourage AI crawlers to reuse cached content yet still refresh daily. Pair with a `Digest` header (SHA-256) so future crawlers can integrity-check without re-downloading.
+
+## 3. Structured Data Augmentation
+- **`hasPart`/`isBasedOn` relations**: Connect FAQ entries to the primary article entity using `hasPart` (on the article) and `isPartOf` (on each Q/A). Cite official guidance PDFs with `isBasedOn` to highlight source provenance.
+- **Medical guidelines metadata**: Add `guideline` objects referencing AAP/CDC/Health Canada issuances, including `guidelineSubject` and `legislationLegalValue`, signaling that content follows authoritative policy.
+- **Machine-readable change logs**: Extend JSON-LD with an `UpdateAction` entry noting the latest revision, what changed, and who approved it. This helps LLMs reason about versioning.
+
+## 4. Multilingual & Regional Strategy
+- **Locale roll-ups**: Publish region index pages (e.g., `/en-ca/feeding/`) containing `<link rel="alternate" hreflang="x-default">` pointing to a global overview. This clarifies canonical clustering for search engines and LLMs.
+- **Unit localization matrix**: Provide a static JSON resource (e.g., `/units.json`) mapping imperial ↔ metric conversions used across the site. Reference it from components and mention it in docs so crawlers know conversions are standardized.
+
+## 5. Governance, Monitoring, and Access Controls
+- **AI crawler registry**: Maintain `/ai-crawler-policy.json` enumerating allowed bots, rate limits, and contact info. Link to it from robots.txt via a comment. This transparency can build trust and is machine-parseable.
+- **Automated anomaly detection**: Configure alerting on unusual crawl patterns (e.g., spikes from unknown UAs, abnormal request paths) and log them in a shared dashboard. Consider weekly reports summarizing AI traffic vs. traditional SEO bots.
+- **Consent & licensing statements**: For each page, include a structured notice (`CreativeWork.license`) clarifying permissible reuse, especially when synthesizing public-domain vs. proprietary guidance.
+
+## 6. Content Lifecycle Operations
+- **Review workflow metadata**: Store reviewer role, review date, and approval status in your Supabase schema and expose via API. This supports future automation (e.g., suppressing out-of-date pages from AI feeds).
+- **Programmatic QA**: Add automated validation (via linting scripts) to ensure every article includes required sections (`Bottom line`, `US vs Canada`, etc.), numerical data with units, and JSON-LD parity with page copy.
+- **Embeddable snippets**: Offer a `/embed/{slug}` endpoint rendering a condensed card with structured data. This encourages third-party distribution and gives LLMs a compact reference.
+
+## 7. Future-facing Enhancements
+- **Vectorized summaries**: Generate and publish cosine-similarity vectors (e.g., via `/ai-feed-vectors.ndjson`) for RAG systems wanting semantic hooks. Include metadata linking vectors to canonical URLs.
+- **Accessibility for synthetic readers**: Document ARIA roles and ensure collapsible sections are keyboard-accessible—some AI assistants render content via headless browsers that respect accessibility APIs.
+- **Data licensing webhooks**: Offer an opt-in webhook where verified AI providers can receive change notifications, logs, or license updates—bridging policy with technical integration.
+
+Implementing the above will deepen trust, improve structured discoverability, and provide clearer contracts for AI agents interacting with the parenting knowledge base without degrading traditional SEO signals.

--- a/public/ai-crawler-policy.json
+++ b/public/ai-crawler-policy.json
@@ -1,0 +1,81 @@
+{
+  "policyVersion": "2025-01-15",
+  "contact": "mailto:support@momaiagent.com",
+  "notes": "Guidance for AI and search crawlers interacting with MomAI properties.",
+  "allowedAgents": [
+    {
+      "userAgent": "GPTBot",
+      "rateLimitPerMinute": 120,
+      "requirements": ["Respect If-Modified-Since", "Announce token usage in request headers"],
+      "acceptableUse": ["Indexing", "Answer generation"],
+      "prohibitedUse": ["Model training without explicit license"]
+    },
+    {
+      "userAgent": "OAI-SearchBot",
+      "rateLimitPerMinute": 120,
+      "requirements": ["Support HEAD freshness checks", "Include contact email in User-Agent"],
+      "acceptableUse": ["Indexing", "Answer generation"],
+      "prohibitedUse": ["Redistribution of proprietary assets"]
+    },
+    {
+      "userAgent": "Google-Extended",
+      "rateLimitPerMinute": 240,
+      "requirements": ["Adhere to Google Publisher Policies"],
+      "acceptableUse": ["AI preview snippets", "Search generative experience"],
+      "prohibitedUse": ["Training unrelated third-party models"]
+    },
+    {
+      "userAgent": "ClaudeBot",
+      "rateLimitPerMinute": 90,
+      "requirements": ["Honor Crawl-delay=1", "Use HTTPS"],
+      "acceptableUse": ["Indexing", "Answer generation"],
+      "prohibitedUse": ["Persistent storage of Supabase endpoints"]
+    },
+    {
+      "userAgent": "PerplexityBot",
+      "rateLimitPerMinute": 60,
+      "requirements": ["Disclose Perplexity-User fetches", "Respect geo fences"],
+      "acceptableUse": ["On-demand retrieval"],
+      "prohibitedUse": ["Background bulk mirroring"]
+    },
+    {
+      "userAgent": "Applebot-Extended",
+      "rateLimitPerMinute": 180,
+      "requirements": ["Request Applebot verification token"],
+      "acceptableUse": ["Generative training for Apple experiences"],
+      "prohibitedUse": ["Sharing datasets externally"]
+    },
+    {
+      "userAgent": "CCBot",
+      "rateLimitPerMinute": 60,
+      "requirements": ["Publish crawl IP ranges"],
+      "acceptableUse": ["Common Crawl snapshotting"],
+      "prohibitedUse": ["Derivative dataset resale"]
+    }
+  ],
+  "disallowedAgents": [
+    {
+      "userAgent": "Perplexity-User",
+      "reason": "User-triggered fetches are validated via WAF token before being served"
+    }
+  ],
+  "contentUsage": {
+    "attributionRequired": true,
+    "license": "https://creativecommons.org/licenses/by-nc/4.0/",
+    "machineReadableFeeds": [
+      {
+        "path": "/ai-feed.ndjson",
+        "description": "Full corpus export for sanctioned partners"
+      },
+      {
+        "path": "/ai-feed-delta.ndjson",
+        "description": "Rolling 30 day changes"
+      }
+    ]
+  },
+  "security": {
+    "waf": "UA + IP double verification enforced",
+    "contactForAccess": "mailto:security@momaiagent.com",
+    "logsRetainedDays": 30
+  }
+}

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,34 @@
-# https://www.robotstxt.org/robotstxt.html
+# MomAI crawler policy — updated 2025-01-15
+# Full machine-readable details: https://www.momaiagent.com/ai-crawler-policy.json
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+User-agent: Googlebot
+Allow: /
+
+User-agent: Bingbot
+Allow: /
+
 User-agent: *
-Disallow:
+Allow: /
+
+Sitemap: https://www.momaiagent.com/sitemap.xml

--- a/public/units.json
+++ b/public/units.json
@@ -1,0 +1,53 @@
+{
+  "version": "2025-01-15",
+  "length": [
+    {
+      "imperial": "inch",
+      "metric": "centimeter",
+      "ratio": 2.54,
+      "useCases": ["growth charts", "toy safety measurements"]
+    },
+    {
+      "imperial": "foot",
+      "metric": "meter",
+      "ratio": 0.3048,
+      "useCases": ["crib clearance", "room safety gating"]
+    }
+  ],
+  "volume": [
+    {
+      "imperial": "fluid_ounce",
+      "metric": "milliliter",
+      "ratio": 29.5735,
+      "useCases": ["formula prep", "medicine dosing"]
+    },
+    {
+      "imperial": "cup",
+      "metric": "milliliter",
+      "ratio": 236.588,
+      "useCases": ["meal planning", "puree storage"]
+    }
+  ],
+  "temperature": [
+    {
+      "imperial": "fahrenheit",
+      "metric": "celsius",
+      "convert": "(value - 32) * 5/9",
+      "useCases": ["nursery climate", "fever thresholds"]
+    }
+  ],
+  "weight": [
+    {
+      "imperial": "pound",
+      "metric": "kilogram",
+      "ratio": 0.453592,
+      "useCases": ["growth tracking", "medication dosing"]
+    },
+    {
+      "imperial": "ounce",
+      "metric": "gram",
+      "ratio": 28.3495,
+      "useCases": ["infant feeding", "solid food portions"]
+    }
+  ]
+}

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -3790,8 +3790,171 @@ const blogPostData = {
   }
 };
 
+const blogPostSummaries: Record<
+  string,
+  {
+    title: string;
+    items: { label: string; value: string }[];
+    sources?: { label: string; url: string }[];
+  }
+> = {
+  "safe-sleep-guidelines-newborns": {
+    title: "Safe sleep snapshot",
+    items: [
+      { label: "Primary question", value: "How to cut SIDS risk at home" },
+      { label: "Age focus", value: "Birth–12 months" },
+      {
+        label: "Key action",
+        value: "Back-to-sleep on a firm, bare crib with 6 months of room-sharing",
+      },
+      { label: "Regions covered", value: "United States · Canada · United Kingdom · European Union" },
+    ],
+    sources: [
+      {
+        label: "AAP 2022 Safe Sleep Policy",
+        url: "https://publications.aap.org/pediatrics/article/150/1/e2022057990/188843",
+      },
+      {
+        label: "Health Canada – Safe Sleep",
+        url: "https://www.canada.ca/en/public-health/services/publications/healthy-living/safe-infant-sleep.html",
+      },
+    ],
+  },
+  "gentle-sleep-training-baby": {
+    title: "Gentle sleep training at-a-glance",
+    items: [
+      { label: "Primary question", value: "How to lengthen night sleep without harsh methods" },
+      { label: "Age focus", value: "4–12 months (developmentally ready infants)" },
+      { label: "Method", value: "Graduated extinction with 3-minute check-ins, +2 minutes each round" },
+      { label: "Supportive habits", value: "Dark 20–22 °C rooms, ≤ 50 dB white noise, age-appropriate naps" },
+    ],
+    sources: [
+      {
+        label: "American Academy of Pediatrics – HealthyChildren Sleep Training",
+        url: "https://www.healthychildren.org/English/ages-stages/baby/sleep/Pages/Getting-Your-Baby-to-Sleep.aspx",
+      },
+      {
+        label: "Cleveland Clinic – Sleep Training Evidence",
+        url: "https://health.clevelandclinic.org/sleep-training-methods",
+      },
+    ],
+  },
+  "newborn-feeding-schedule": {
+    title: "Newborn intake benchmarks",
+    items: [
+      { label: "Primary question", value: "How often and how much should newborns eat" },
+      { label: "Milk frequency", value: "8–12 feeds per 24 h (breast); 60–90 mL every 3 h (formula)" },
+      { label: "Hydration check", value: "≥ 6 wet diapers daily by day 5" },
+      { label: "Regions covered", value: "US · Canada · UK · EU" },
+    ],
+    sources: [
+      {
+        label: "HealthyChildren – Newborn Feeding",
+        url: "https://www.healthychildren.org/English/ages-stages/baby/feeding-nutrition/Pages/Newborn-and-Baby-Feeding-Schedule.aspx",
+      },
+      {
+        label: "NHS – Feeding cues",
+        url: "https://www.nhs.uk/conditions/baby/breastfeeding-and-bottle-feeding/bottle-feeding/how-much-formula-does-my-baby-need/",
+      },
+    ],
+  },
+  "starting-solids-6-months": {
+    title: "Starting solids essentials",
+    items: [
+      { label: "Primary question", value: "How to introduce solids alongside milk" },
+      { label: "Readiness window", value: "Around 6 months when baby sits with support & has head control" },
+      { label: "First foods", value: "Iron-rich purées or soft BLW strips + repeated allergen exposure" },
+      { label: "Safety", value: "No honey < 12 months; continue breast/formula feeds" },
+    ],
+    sources: [
+      { label: "WHO Complementary Feeding", url: "https://www.who.int/health-topics/complementary-feeding" },
+      {
+        label: "HealthyChildren – Starting Solids",
+        url: "https://www.healthychildren.org/English/ages-stages/baby/feeding-nutrition/Pages/Switching-To-Solid-Foods.aspx",
+      },
+    ],
+  },
+  "infant-vaccine-schedule-2025": {
+    title: "First-year vaccine roadmap",
+    items: [
+      { label: "Primary question", value: "Which vaccines are due at each well-visit" },
+      { label: "Birth", value: "Hepatitis B dose #1 within 24 h" },
+      { label: "2–6 months", value: "DTaP, Hib, IPV, PCV, Rotavirus series + seasonal flu ≥ 6 months" },
+      { label: "12 months", value: "MMR, Varicella, PCV booster, Hep A (US)" },
+    ],
+    sources: [
+      {
+        label: "CDC – 2025 Immunization Schedule",
+        url: "https://www.cdc.gov/vaccines/schedules/hcp/imz/child-adolescent.html",
+      },
+      {
+        label: "ECDC – EU Childhood Schedule Overview",
+        url: "https://vaccination-info.europa.eu/en",
+      },
+    ],
+  },
+  "sick-baby-fever-cold-care": {
+    title: "Fever & cold triage cues",
+    items: [
+      { label: "Primary question", value: "When to manage at home vs call the doctor" },
+      { label: "Seek urgent care", value: "Fever ≥ 100.4 °F (38 °C) under 3 months or breathing distress" },
+      { label: "Home comfort", value: "Saline drops + suction, humidifier, weight-based acetaminophen" },
+      { label: "Red-flag hydration", value: "< 3 wet diapers in 24 h" },
+    ],
+    sources: [
+      {
+        label: "AAP – Fever and Your Baby",
+        url: "https://www.healthychildren.org/English/health-issues/conditions/fever/Pages/Fevers.aspx",
+      },
+      {
+        label: "NHS – Caring for a Sick Baby",
+        url: "https://www.nhs.uk/conditions/baby/health/fever-in-babies/",
+      },
+    ],
+  },
+  "postpartum-depression-signs-help": {
+    title: "Postpartum mental health signals",
+    items: [
+      { label: "Primary question", value: "How to recognise and respond to PPD" },
+      { label: "When to get help", value: "Low mood > 2 weeks, intrusive thoughts, bonding difficulty" },
+      { label: "Evidence-based care", value: "CBT/IPT therapy, SSRI medication compatible with breastfeeding" },
+      { label: "24/7 support", value: "PSI +1-800-944-4773, NHS 111, EU 112" },
+    ],
+    sources: [
+      {
+        label: "CDC – Depression After Pregnancy",
+        url: "https://www.cdc.gov/reproductivehealth/features/postpartum-depression/index.html",
+      },
+      {
+        label: "NHS – Postnatal Depression",
+        url: "https://www.nhs.uk/mental-health/conditions/post-natal-depression/overview/",
+      },
+    ],
+  },
+  "babyproofing-home-safety": {
+    title: "Home safety checklist",
+    items: [
+      { label: "Primary question", value: "How to prevent the top household injuries" },
+      { label: "High-impact fixes", value: "Anchor furniture, install hardware stair gates, lock cabinets" },
+      { label: "Choking rule", value: "Remove any item that fits through a toilet-paper roll" },
+      { label: "Water safety", value: "Set heaters ≤ 120 °F (49 °C) and stay within arm's reach at bath time" },
+    ],
+    sources: [
+      {
+        label: "National Safety Council – Home Safety",
+        url: "https://www.nsc.org/community-safety/safety-topics/child-safety",
+      },
+      {
+        label: "Safe Kids Worldwide – Home Safety Checklist",
+        url: "https://www.safekids.org/safetytips/field_risks/home-safety",
+      },
+    ],
+  },
+};
+
 const BlogPost: React.FC = () => {
   const { slug } = useParams<{ slug: string }>();
+  const summary = slug ? blogPostSummaries[slug] : undefined;
   const post = blogPostData[slug as keyof typeof blogPostData];
 
   if (!post) {
@@ -3811,7 +3974,7 @@ const BlogPost: React.FC = () => {
   }
 
   // 结构化数据
-  const blogPostingJsonLd = {
+  const blogPostingJsonLd: Record<string, any> = {
     "@context": "https://schema.org",
     "@type": "BlogPosting",
     "headline": post.title,
@@ -3841,6 +4004,25 @@ const BlogPost: React.FC = () => {
       }
     }
   };
+
+  if (summary) {
+    blogPostingJsonLd.hasPart = [
+      {
+        "@type": "WebPageElement",
+        "name": summary.title,
+        "cssSelector": "#quick-fact-sheet",
+        "abstract": summary.items.map((item) => `${item.label}: ${item.value}`).join(" | ")
+      }
+    ];
+
+    if (summary.sources?.length) {
+      blogPostingJsonLd.isBasedOn = summary.sources.map((source) => ({
+        "@type": "CreativeWork",
+        "name": source.label,
+        "url": source.url
+      }));
+    }
+  }
 
   return (
     <>
@@ -3887,8 +4069,54 @@ const BlogPost: React.FC = () => {
               </div>
             </header>
 
+            {summary && (
+              <section
+                id="quick-fact-sheet"
+                aria-labelledby="quick-fact-sheet-title"
+                className="mb-12 rounded-2xl border border-indigo-100 bg-indigo-50/60 p-6 shadow-sm"
+              >
+                <h2
+                  id="quick-fact-sheet-title"
+                  className="text-xl font-semibold text-indigo-900 mb-4 tracking-tight"
+                >
+                  {summary.title}
+                </h2>
+                <dl className="grid gap-4 md:grid-cols-2">
+                  {summary.items.map((item) => (
+                    <div key={item.label} className="space-y-1">
+                      <dt className="text-xs font-semibold uppercase tracking-wide text-indigo-600">
+                        {item.label}
+                      </dt>
+                      <dd className="text-base text-gray-900 leading-snug">{item.value}</dd>
+                    </div>
+                  ))}
+                </dl>
+                {summary.sources?.length ? (
+                  <div className="mt-6">
+                    <h3 className="text-xs font-semibold uppercase tracking-wide text-indigo-600">
+                      Source references
+                    </h3>
+                    <ul className="mt-2 space-y-1 text-sm text-indigo-900">
+                      {summary.sources.map((source) => (
+                        <li key={source.url}>
+                          <a
+                            href={source.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="underline decoration-dotted underline-offset-2 hover:text-indigo-700"
+                          >
+                            {source.label}
+                          </a>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : null}
+              </section>
+            )}
+
             {/* Article Content */}
-            <div 
+            <div
               className="prose prose-lg max-w-none prose-headings:text-gray-800 prose-p:text-gray-700 prose-strong:text-gray-900 prose-blockquote:bg-blue-50 prose-blockquote:border-l-blue-400 prose-table:border-collapse prose-table:border prose-table:border-gray-300 prose-ul:list-disc prose-ul:pl-6 prose-ol:list-decimal prose-ol:pl-6 prose-li:my-1 prose-h2:text-2xl prose-h2:font-bold prose-h2:mt-8 prose-h2:mb-4 prose-h3:text-xl prose-h3:font-semibold prose-h3:mt-6 prose-h3:mb-3 prose-p:leading-relaxed prose-p:mb-4 prose-blockquote:p-4 prose-blockquote:my-6 prose-blockquote:rounded-r-lg"
               dangerouslySetInnerHTML={{ __html: post.content }}
             />


### PR DESCRIPTION
## Summary
- add a reusable quick fact sheet module to blog posts and attach it to structured data for AEO
- publish ai-crawler-policy.json and refresh robots.txt to document allowed AI crawlers
- expose a units.json conversion matrix for consistent imperial/metric references

## Testing
- npm run build *(fails: missing module '@/lib/cache')*

------
https://chatgpt.com/codex/tasks/task_b_68e3e96a6d0483228acbb8f3af607df6